### PR TITLE
Use %SYSTEMROOT%\Temp when running as LocalSystem

### DIFF
--- a/templates/import_from_pem.ps1.erb
+++ b/templates/import_from_pem.ps1.erb
@@ -1,5 +1,11 @@
 $ErrorActionPreference = 'Continue'
 
+if($env:USERNAME -eq "$($env:COMPUTERNAME)`$") {
+    # Workaround issues when running puppet as LocalSystem
+    # (we can't to write to the default TEMP folder for LocalSystem... 😭)
+    $env:TEMP = $env:TMP = $env:SYSTEMROOT + '\Temp'
+}
+
 $certfile = [System.IO.Path]::GetTempFileName()
 $keyfile = [System.IO.Path]::GetTempFileName()
 $pfxfile = [System.IO.Path]::GetTempFileName()


### PR DESCRIPTION
Default temp folder isn't writable when running as Local System