### PR TITLE
Fix variable interpolation issue

### DIFF
--- a/templates/set_acl_on_private_key.ps1.erb
+++ b/templates/set_acl_on_private_key.ps1.erb
@@ -1,5 +1,5 @@
 $certStorePath = "<%= @store %>"
-$identity = "<%= @identity %>"
+$identity = '<%= @identity %>'
 $certThumbprint = "<%= @cert_thumbprint %>"
 $permission = "<%= @permission %>"
 $type = "<%= @type %>"

--- a/templates/should_set_acl_on_private_key.ps1.erb
+++ b/templates/should_set_acl_on_private_key.ps1.erb
@@ -1,5 +1,5 @@
 $certStorePath = "<%= @store %>"
-$identity = "<%= @identity %>"
+$identity = '<%= @identity %>'
 $certThumbprint = "<%= @cert_thumbprint %>"
 $permission = "<%= @permission %>"
 $type = "<%= @type %>"


### PR DESCRIPTION
Use `'` in the PowerShell template to prevent Powershell from trying to do variable interpolation. We never expect a variable here, and SQL service accounts regularly have `$` symbols in them