### PR TITLE
sslcertificate::from_pem - add switch to remove duplicates immediately

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -65,15 +65,6 @@ platforms:
     transport:
       name: winrm
       winrm_transport: plaintext
-  - name: windows-2012r2
-    driver_plugin: vagrant
-    driver_config:
-      box: red-gate/windows-2012r2
-    provisioner:
-      puppet_version: "6.28.0"
-    transport:
-      name: winrm
-      winrm_transport: plaintext
 
 suites:
   - name: windows_tests

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'puppet-lint'
 
-gem 'test-kitchen'
+gem 'test-kitchen', '< 3.8.0' # pin to pre 3.8.0 which introduced a change to how it uploads files which breaks ssh_tgz upload in the kitchen-zip module
 gem 'kitchen-puppet', '>= 3.6.0'
 gem 'kitchen-vagrant'
 gem 'kitchen-zip', :git => 'https://github.com/red-gate/kitchen-zip', :branch => 'master'

--- a/manifests/from_pem.pp
+++ b/manifests/from_pem.pp
@@ -21,7 +21,7 @@ define sslcertificate::from_pem (
   String $store = 'LocalMachine\My',
   Boolean $exportable = false,
   Optional[Integer] $remove_expired_certs_after = 30, # Days,
-  # Default of "30", to keep the behaviour the same, "0" for immediate removal, "undef" to not remove.
+  # Default of "30", to keep the behaviour the same, "-1" for immediate removal, "undef" to not remove.
 ) {
   require sslcertificate::openssl
 

--- a/manifests/from_pem.pp
+++ b/manifests/from_pem.pp
@@ -46,13 +46,4 @@ define sslcertificate::from_pem (
       logoutput => true,
     }
   }
-
-  if $remove_expired_certs {
-    exec { "${title}_RemoveExpiredCerts":
-      provider  => 'powershell',
-      command   => template('sslcertificate/remove_expired_certs.ps1.erb'),
-      onlyif    => template('sslcertificate/should_remove_expired_certs.ps1.erb'),
-      logoutput => true,
-    }
-  }
 }

--- a/manifests/from_pem.pp
+++ b/manifests/from_pem.pp
@@ -20,8 +20,7 @@ define sslcertificate::from_pem (
   String $key_content,
   String $store = 'LocalMachine\My',
   Boolean $exportable = false,
-  Boolean $remove_expired_certs = true,
-  Boolean $remove_immediately = false
+  Integer $remove_expired_certs_after = 30, # Days, default of 30, to keep the behaviour the same, option to set to 0 for immediate removal.
 ) {
   require sslcertificate::openssl
 
@@ -38,7 +37,7 @@ define sslcertificate::from_pem (
     logoutput => true,
   }
 
-  if $remove_expired_certs {
+  if $remove_expired_certs_after {
     exec { "${title}_RemoveExpiredCerts":
       provider  => 'powershell',
       command   => template('sslcertificate/remove_expired_certs.ps1.erb'),

--- a/manifests/from_pem.pp
+++ b/manifests/from_pem.pp
@@ -20,7 +20,8 @@ define sslcertificate::from_pem (
   String $key_content,
   String $store = 'LocalMachine\My',
   Boolean $exportable = false,
-  Boolean $remove_expired_certs = true
+  Boolean $remove_expired_certs = true,
+  Boolean $remove_immediately = false
 ) {
   require sslcertificate::openssl
 
@@ -35,6 +36,15 @@ define sslcertificate::from_pem (
     command   => template('sslcertificate/import_from_pem.ps1.erb'),
     onlyif    => template('sslcertificate/should_import_from_pem.ps1.erb'),
     logoutput => true,
+  }
+
+  if $remove_expired_certs {
+    exec { "${title}_RemoveExpiredCerts":
+      provider  => 'powershell',
+      command   => template('sslcertificate/remove_expired_certs.ps1.erb'),
+      onlyif    => template('sslcertificate/should_remove_expired_certs.ps1.erb'),
+      logoutput => true,
+    }
   }
 
   if $remove_expired_certs {

--- a/manifests/from_pem.pp
+++ b/manifests/from_pem.pp
@@ -20,7 +20,8 @@ define sslcertificate::from_pem (
   String $key_content,
   String $store = 'LocalMachine\My',
   Boolean $exportable = false,
-  Integer $remove_expired_certs_after = 30, # Days, default of 30, to keep the behaviour the same, option to set to 0 for immediate removal.
+  Optional[Integer] $remove_expired_certs_after = 30, # Days,
+  # Default of "30", to keep the behaviour the same, "0" for immediate removal, "undef" to not remove.
 ) {
   require sslcertificate::openssl
 

--- a/templates/remove_expired_certs.ps1.erb
+++ b/templates/remove_expired_certs.ps1.erb
@@ -9,11 +9,7 @@ function Get-CertName($certificate) {
 $cert_cn = Get-CertName $cert
 
 function Test-ShouldBeRemoved($certificate) {
-    if(<%= @remove_immediately %>) {
-        ($certificate.NotAfter -ne $cert.NotAfter) -and (Get-CertName $certificate) -eq $cert_cn
-    } else {
-        ($certificate.NotAfter -lt ((get-date).AddDays(-30))) -and (Get-CertName $certificate) -eq $cert_cn
-    }
+    ($certificate.NotAfter -lt ((get-date).AddDays(-<%= @remove_expired_certs_after %>))) -and (Get-CertName $certificate) -eq $cert_cn
 }
 
 Get-ChildItem Cert:\<%= @store %> | Where-Object { Test-ShouldBeRemoved $_ } | Remove-Item -Verbose

--- a/templates/remove_expired_certs.ps1.erb
+++ b/templates/remove_expired_certs.ps1.erb
@@ -9,7 +9,7 @@ function Get-CertName($certificate) {
 $cert_cn = Get-CertName $cert
 
 function Test-ShouldBeRemoved($certificate) {
-    ($certificate.NotAfter -lt ((get-date).AddDays(-<%= @remove_expired_certs_after %>))) -and (Get-CertName $certificate) -eq $cert_cn
+    ($certificate.NotAfter -lt ((get-date).AddDays(-1 * <%= @remove_expired_certs_after %>))) -and (Get-CertName $certificate) -eq $cert_cn
 }
 
 Get-ChildItem Cert:\<%= @store %> | Where-Object { Test-ShouldBeRemoved $_ } | Remove-Item -Verbose

--- a/templates/remove_expired_certs.ps1.erb
+++ b/templates/remove_expired_certs.ps1.erb
@@ -9,7 +9,11 @@ function Get-CertName($certificate) {
 $cert_cn = Get-CertName $cert
 
 function Test-ShouldBeRemoved($certificate) {
-    ($certificate.NotAfter -lt ((get-date).AddDays(-30))) -and (Get-CertName $certificate) -eq $cert_cn
+    if(<%= @remove_immediately %>) {
+        ($certificate.NotAfter -ne $cert.NotAfter) -and (Get-CertName $certificate) -eq $cert_cn
+    } else {
+        ($certificate.NotAfter -lt ((get-date).AddDays(-30))) -and (Get-CertName $certificate) -eq $cert_cn
+    }
 }
 
 Get-ChildItem Cert:\<%= @store %> | Where-Object { Test-ShouldBeRemoved $_ } | Remove-Item -Verbose


### PR DESCRIPTION
sslcertificate::from_pem currently leaves expired certificates around for 30 days, before it removes them.
This causes issues with NPS still sometimes trying to use the old certificate and breaking WiFi auth.

This PR adds a switch of `remove_immediately` that we can pass from puppet when using the module on a server.
The existing logic gets certificates from the local cert store that match the certificate name, looks at the expiry date, checks if it's more than 30 days ago and removes them.
The new logic if the switch is used should get certificates from the local store, matches the name, then checks the expiry date again the current one being stored in Vault, and removes them if they don't match. which should get rid of dupes on the first puppet run after there are multiples.

This Puppet resources already notifies the IAS service, so should restart it and confirm it's using the current cert.

Is this a sensible plan?
Do we still want to keep expired certs around for 30 days? I assume this was a thing for when we weren't positive the cert renewal process worked?
Would we prefer to just compare each certs `notafter` date to todays date and remove them the first puppet run after they expire?